### PR TITLE
Reviewer Mike - Practical updates to the timer API

### DIFF
--- a/include/appserver.h
+++ b/include/appserver.h
@@ -57,6 +57,10 @@ class AppServer;
 class AppServerTsx;
 
 
+/// Typedefs for AppServer-specific elements
+typedef intptr_t TimerID;
+
+
 /// The AppServerTsxHelper class handles the underlying service-related
 /// processing of a single transaction for an AppServer.  Once a service has
 /// been triggered as part of handling a transaction, the related
@@ -164,22 +168,22 @@ public:
   /// and restarted with the new duration and context parameter.
   ///
   /// @returns             - true/false indicating when the timer is programmed.
-  /// @param  id           - A unique identifier for the timer.
   /// @param  context      - Context parameter returned on the callback.
+  /// @param  id           - A unique identifier for the timer.
   /// @param  duration     - Timer duration in milliseconds.
-  virtual bool schedule_timer(int id, void* context, int duration) = 0;
+  virtual bool schedule_timer(void* context, TimerID& id, int duration) = 0;
 
   /// Cancels the timer with the specified identifier.  This is a no-op if
   /// there is no timer with this identifier running.
   ///
   /// @param  id           - The unique identifier for the timer.
-  virtual void cancel_timer(int id) = 0;
+  virtual void cancel_timer(TimerID id) = 0;
 
   /// Queries the state of a timer.
   ///
   /// @returns             - true if the timer is running, false otherwise.
   /// @param  id           - The unique identifier for the timer. 
-  virtual bool timer_running(int id) = 0;
+  virtual bool timer_running(TimerID id) = 0;
 
   /// Returns the SAS trail identifier that should be used for any SAS events
   /// related to this service invocation.
@@ -302,10 +306,9 @@ public:
 
   /// Called when a timer programmed by the AppServerTsx expires.
   ///
-  /// @param  id           - The unique identifier for the timer.
   /// @param  context      - The context parameter specified when the timer
   ///                        was scheduled.
-  virtual void on_timer_expiry(int id, void* context) {}
+  virtual void on_timer_expiry(void* context) {}
 
 protected:
   /// Adds the service to the underlying SIP dialog with the specified dialog
@@ -407,24 +410,24 @@ protected:
   /// and restarted with the new duration and context parameter.
   ///
   /// @returns             - true/false indicating when the timer is programmed.
-  /// @param  id           - A unique identifier for the timer.
   /// @param  context      - Context parameter returned on the callback.
+  /// @param  id           - A unique identifier for the timer.
   /// @param  duration     - Timer duration in milliseconds.
-  bool schedule_timer(int id, void* context, int duration)
-    {return _helper->schedule_timer(id, context, duration);}
+  bool schedule_timer(void* context, TimerID& id,int duration)
+    {return _helper->schedule_timer(context, id, duration);}
 
   /// Cancels the timer with the specified identifier.  This is a no-op if
   /// there is no timer with this identifier running.
   ///
   /// @param  id           - The unique identifier for the timer.
-  void cancel_timer(int id)
+  void cancel_timer(TimerID id)
     {_helper->cancel_timer(id);}
 
   /// Queries the state of a timer.
   ///
   /// @returns             - true if the timer is running, false otherwise.
   /// @param  id           - The unique identifier for the timer.
-  bool timer_running(int id)
+  bool timer_running(TimerID id)
     {return _helper->timer_running(id);}
 
   /// Returns the SAS trail identifier that should be used for any SAS events

--- a/test/mockappserver.hpp
+++ b/test/mockappserver.hpp
@@ -67,9 +67,9 @@ public:
   MOCK_METHOD2(cancel_fork, void(int, int));
   MOCK_METHOD1(free_msg, void(pjsip_msg*&));
   MOCK_METHOD1(get_pool, pj_pool_t*(const pjsip_msg*));
-  MOCK_METHOD3(schedule_timer, bool(int, void*, int));
-  MOCK_METHOD1(cancel_timer, void(int));
-  MOCK_METHOD1(timer_running, bool(int));
+  MOCK_METHOD3(schedule_timer, bool(void*, TimerID&, int));
+  MOCK_METHOD1(cancel_timer, void(TimerID));
+  MOCK_METHOD1(timer_running, bool(TimerID));
 };
 
 


### PR DESCRIPTION
The pjsip timer API is a bit weird and copying it leads to unnatural code (or too much visibility up to the lower layers of the underlying function).  I've updated to a saner API as part of adding the timer functionality to SproutletProxy.
